### PR TITLE
Adding install requirements and provided packages

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,4 +15,10 @@ setup(
     author_email="opensource@yelp.com",
     setup_requires="setuptools",
     packages=find_packages(exclude=["tests"]),
+    provides=["amira"],
+    install_requires=[
+        "boto",
+        "osxcollector_output_filters",
+        "simplejson",
+    ],
 )


### PR DESCRIPTION
`setup.py` was missing `provides` and `install_requires` parameters.