### PR TITLE
Removed setup.py test

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,6 @@ install_command = pip install --use-wheel {opts} {packages}
 deps = -rrequirements-dev.txt
 whitelist_externals = coverage
 commands =
-    {envpython} setup.py test
     coverage --version
     coverage run --source=amira/,tests/ -m pytest {posargs}
     coverage report -m


### PR DESCRIPTION
python setup.py test asks setuptools to install test dependencies and run tests. This only should be called IF you are using unittest. We are using tox and pytest instead, so all this command does is install dependencies again, causing it to fail if you need to use pip/wheels for dependencies.