### PR TITLE
Migrate from legacy boto to boto3

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,9 +43,9 @@ also available when running AMIRA.
 
 ### AWS credentials
 
-AMIRA uses boto to interface with AWS.
-You can supply the credentials using either of the possible
-[boto config files](http://boto.cloudhackers.com/en/latest/boto_config_tut.html#details).
+AMIRA uses boto3 to interface with AWS.
+You can supply credentials using either of the possible
+[configuration options](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/credentials.html).
 
 The credentials should allow reading and deleting SQS messages
 from the SQS queue specified in the AMIRA config as well as

--- a/amira/__init__.py
+++ b/amira/__init__.py
@@ -2,4 +2,4 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
-__version__ = '1.2.2'
+__version__ = '2.0.0'

--- a/amira/s3.py
+++ b/amira/s3.py
@@ -4,8 +4,7 @@ from __future__ import unicode_literals
 
 import logging
 
-import boto
-from boto.s3.key import Key
+import boto3
 
 from amira.results_uploader import ResultsUploader
 
@@ -14,30 +13,26 @@ class S3Handler(object):
     """Handles the operations with S3, like retrieving the key
     (object) contents from a bucket and creating a new key
     (object) with the contents of a given file.
-    AWS and boto use the ambiguous term "key" to describe the objects
+    AWS uses the ambiguous term "key" to describe the objects
     inside the S3 bucket. They are unrelated to AWS keys used to access
     the resources.
     """
 
     def __init__(self):
-        self._s3_connection = boto.connect_s3()
+        self._s3_connection = boto3.client('s3')
 
     def get_contents_as_string(self, bucket_name, key_name):
         """Retrieves the S3 key (object) contents.
 
         :param bucket_name: The S3 bucket name.
         :type bucket_name: string
-
         :param key_name: The S3 key (object) name.
         :type key_name: string
-
-        :returns: The key (object) contents as a string.
-        :rtype: string
+        :returns: The key (object) contents as a bytes (str in py2).
+        :rtype: bytes
         """
-        bucket = self._s3_connection.get_bucket(bucket_name, validate=False)
-        key = bucket.get_key(key_name)
-        contents = key.get_contents_as_string()
-        return contents
+        response = self._s3_connection.get_object(Bucket=bucket_name, Key=key_name)
+        return response['Body'].read()
 
 
 class S3ResultsUploader(ResultsUploader):
@@ -50,19 +45,7 @@ class S3ResultsUploader(ResultsUploader):
 
     def __init__(self, bucket_name):
         self._bucket_name = bucket_name
-
-        logging.info(
-            'Connecting to S3 to obtain access to {0} bucket.'.format(
-                bucket_name,
-            ),
-        )
-        s3_connection = boto.connect_s3()
-        self._bucket = s3_connection.get_bucket(bucket_name, validate=False)
-        logging.info(
-            'S3 bucket {0} retrieved successfully.'.format(
-                bucket_name,
-            ),
-        )
+        self._s3_connection = boto3.client('s3')
 
     def upload_results(self, results):
         """Uploads the analysis results to an S3 bucket.
@@ -77,15 +60,9 @@ class S3ResultsUploader(ResultsUploader):
                 'Uploading the analysis results in the file "{0}" to the S3 '
                 'bucket "{1}"'.format(file_meta_info.name, self._bucket_name),
             )
-            self._create_object_from_file(file_meta_info)
-
-    def _create_object_from_file(self, file_meta_info):
-        """Creates a new key (object) in the S3 bucket with the
-        contents of a given file.
-        """
-        key = Key(self._bucket)
-        key.key = file_meta_info.name
-        key.set_contents_from_file(
-            file_meta_info.content,
-            headers={'Content-Type': file_meta_info.content_type},
-        )
+            self._s3_connection.put_object(
+                Bucket=self._bucket_name,
+                Key=file_meta_info.name,
+                ContentType=file_meta_info.content_type,
+                Body=file_meta_info.content,
+            )

--- a/amira/sqs.py
+++ b/amira/sqs.py
@@ -5,9 +5,8 @@ from __future__ import unicode_literals
 import logging
 from collections import namedtuple
 
-import boto.sqs
+import boto3
 import simplejson
-from boto.sqs.message import RawMessage
 
 
 # 10 is the maximum number of messages to read at once:
@@ -32,52 +31,34 @@ class SqsHandler(object):
     """
 
     def __init__(self, region_name, queue_name):
-        self._setup_sqs_queue(region_name, queue_name)
-
-    def _setup_sqs_queue(self, region_name, queue_name):
-        """Connects to the SQS queue in a given AWS region.
+        """ Connects to the SQS queue in a given AWS region.
 
         :param region_name: The AWS region name.
         :type region_name: string
         :param queue_name: The SQS queue name.
         :type queue_name: string
         """
-        sqs_connection = boto.sqs.connect_to_region(region_name)
-        self.sqs_queue = sqs_connection.get_queue(queue_name)
-
-        if not self.sqs_queue:
-            raise SqsQueueNotFoundException(queue_name)
-
+        sqs_connection = boto3.resource('sqs', region_name=region_name)
+        self.sqs_queue = sqs_connection.get_queue_by_name(QueueName=queue_name)
         logging.info(
-            'Successfully connected to {0} SQS queue'.format(
-                queue_name,
-            ),
+            'Successfully connected to {} SQS queue'.format(queue_name),
         )
-
-        self.sqs_queue.set_message_class(RawMessage)
 
     def get_created_objects(self):
         """Retrieves the S3 event notifications about the objects
         created in the OSXCollector output bucket yields the (bucket
         name, key name) pairs describing these objects.
         """
-        messages = self.sqs_queue.get_messages(MAX_NUMBER_MESSAGES)
+        messages = self.sqs_queue.receive_messages(MaxNumberOfMessages=MAX_NUMBER_MESSAGES)
         logging.info(
-            'Received {0} message(s) from the SQS queue'.format(
-                len(messages),
-            ),
+            'Received {0} message(s) from the SQS queue'.format(len(messages)),
         )
-
         if messages:
             for message in messages:
-                objects_created = self._retrieve_created_objects_from_message(
-                    message,
-                )
-
+                objects_created = self._retrieve_created_objects_from_message(message)
                 for object_created in objects_created:
                     yield object_created
-
-            self.sqs_queue.delete_message_batch(messages)
+                message.delete()
 
     def _retrieve_created_objects_from_message(self, message):
         """Retrieves the bucket name and the key name, describing the
@@ -90,35 +71,20 @@ class SqsHandler(object):
                         format.
         :type message: string
         """
-        json_body = message.get_body()
-        body = simplejson.loads(json_body)
-
+        body = simplejson.loads(message.body)
         if 'Records' not in body:
             logging.warning(
                 '"Records" field not found in the SQS message. '
                 'Message body: {0}'.format(body),
             )
             return []
-
-        records = body['Records']
-        return self._extract_created_objects_from_records(records)
+        return self._extract_created_objects_from_records(body['Records'])
 
     def _extract_created_objects_from_records(self, records):
         logging.info(
             'Found {0} record(s) in the SQS message'.format(len(records)),
         )
-
         for record in records:
             bucket_name = record['s3']['bucket']['name']
             key_name = record['s3']['object']['key']
             yield CreatedObject(bucket_name=bucket_name, key_name=key_name)
-
-
-class SqsQueueNotFoundException(Exception):
-    """An exception thrown when the SQS queue cannot be found."""
-
-    def __init__(self, queue_name):
-        self.queue_name = queue_name
-
-    def __str__(self):
-        return 'SQS queue {0} not found.'.format(self.queue_name)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-boto==2.49.0
+boto3==1.14.62
 osxcollector_output_filters==1.1.1
 simplejson==3.16.0

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ setup(
     packages=find_packages(exclude=['tests']),
     provides=['amira'],
     install_requires=[
-        'boto',
+        'boto3',
         'osxcollector_output_filters>=1.1.1',
         'simplejson',
     ],

--- a/tests/sqs_test.py
+++ b/tests/sqs_test.py
@@ -2,23 +2,26 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
-import boto
 import pytest
 import simplejson
 from mock import MagicMock
+from mock import patch
 
 from amira.sqs import SqsHandler
-from amira.sqs import SqsQueueNotFoundException
 
 
 TEST_DATA_DIR_PATH = 'tests/data'
 
 
 @pytest.fixture
-def mock_sqs_queue():
-    boto.sqs.connect_to_region = MagicMock()
-    sqs_connection_mock = boto.sqs.connect_to_region.return_value
-    return sqs_connection_mock.get_queue.return_value
+def sqs_handler():
+    with patch('amira.sqs.boto3') as mock_boto3:
+        handler = SqsHandler('us-west-1', 'godzilla')
+        mock_boto3.resource.assert_called_once_with('sqs', region_name='us-west-1')
+        mock_boto3.resource.return_value.get_queue_by_name.assert_called_once_with(
+            QueueName='godzilla',
+        )
+        yield handler
 
 
 def read_s3_event_notifications_file(s3_event_notifications_file_path):
@@ -31,9 +34,7 @@ def read_s3_event_notifications_file(s3_event_notifications_file_path):
     return json_s3_event_notifications
 
 
-def create_s3_event_notification_message_mocks(
-        s3_event_notifications_file_name,
-):
+def create_s3_event_notification_message_mocks(s3_event_notifications_file_name):
     """Creates SQS queue message mocks that will return the JSON content of
     `s3_event_notifications_file_path` JSON file as the body of the message.
     """
@@ -43,11 +44,10 @@ def create_s3_event_notification_message_mocks(
     json_s3_event_notifications = read_s3_event_notifications_file(
         s3_event_notifications_file_path,
     )
-    s3_event_notification_message_mocks = [
-        MagicMock(**{'get_body.return_value': json_s3_event_notification})
+    return [
+        MagicMock(body=json_s3_event_notification)
         for json_s3_event_notification in json_s3_event_notifications
     ]
-    return s3_event_notification_message_mocks
 
 
 def mock_s3_event_notifications(
@@ -58,41 +58,25 @@ def mock_s3_event_notifications(
     In this case only one as the test cases do not operate on more than
     one message.
     """
-    s3_event_notification_message_mocks = \
-        create_s3_event_notification_message_mocks(
-            s3_event_notifications_file_name,
-        )
-    mock_sqs_queue.get_messages.side_effect = \
-        [s3_event_notification_message_mocks]
+    s3_event_notification_message_mocks = create_s3_event_notification_message_mocks(
+        s3_event_notifications_file_name,
+    )
+    mock_sqs_queue.receive_messages.side_effect = [s3_event_notification_message_mocks]
     return s3_event_notification_message_mocks
 
 
 class TestSqsHandler(object):
 
-    def test_queue_not_found(self):
-        boto.sqs.connect_to_region = MagicMock()
-        sqs_connection_mock = boto.sqs.connect_to_region.return_value
-        sqs_connection_mock.get_queue.return_value = None
-
-        with pytest.raises(SqsQueueNotFoundException) as e:
-            SqsHandler('us-west-1', 'godzilla')
-
-        assert 'SQS queue godzilla not found.' == str(e.value)
-        boto.sqs.connect_to_region.assert_called_once_with('us-west-1')
-        sqs_connection_mock.get_queue.assert_called_once_with('godzilla')
-
-    def test_get_created_objects(self, mock_sqs_queue):
+    def test_get_created_objects(self, sqs_handler):
         s3_event_notification_message_mocks = mock_s3_event_notifications(
-            mock_sqs_queue, 's3_event_notifications.json',
+            sqs_handler.sqs_queue, 's3_event_notifications.json',
         )
-        sqs_handler = SqsHandler('us-west-1', 'godzilla')
         created_objects = sqs_handler.get_created_objects()
         actual_key_names = [
             created_object.key_name
             for created_object in created_objects
         ]
-
-        expected_key_names = [
+        assert actual_key_names == [
             'AMIRA-1561-2016_01_11-10_54_07.tar.gz',
             'AMIRA-1562-2016_01_11-10_54_47.tar.gz',
             'AMIRA-1563-2016_01_11-10_54_58.tar.gz',
@@ -101,31 +85,20 @@ class TestSqsHandler(object):
             'AMIRA-1566-2016_01_11-10_55_49.tar.gz',
             'AMIRA-1567-2016_01_11-10_56_09.tar.gz',
         ]
-        assert expected_key_names == actual_key_names
+        for message_mock in s3_event_notification_message_mocks:
+            message_mock.delete.assert_called_once_with()
 
-        mock_sqs_queue.delete_message_batch.assert_called_once_with(
-            s3_event_notification_message_mocks,
-        )
-
-    def test_get_created_objects_no_created_objects(self, mock_sqs_queue):
-        mock_sqs_queue.get_messages.side_effect = [[]]
-
-        sqs_handler = SqsHandler('us-west-1', 'godzilla')
+    def test_get_created_objects_no_created_objects(self, sqs_handler):
+        sqs_handler.sqs_queue.receive_messages.side_effect = [[]]
         created_objects = sqs_handler.get_created_objects()
-        assert 0 == len(list(created_objects))
+        assert not list(created_objects)
 
-        assert mock_sqs_queue.delete_message_batch.called is False
-
-    def test_get_created_objects_no_records(self, mock_sqs_queue):
+    def test_get_created_objects_no_records(self, sqs_handler):
         """Tests the behavior of `get_created_objects()` method in case
         the message received from SQS does not contain the "Records"
         field in the message body.
         """
         mock_s3_event_notifications(
-            mock_sqs_queue, 's3_test_event_notification.json',
+            sqs_handler.sqs_queue, 's3_test_event_notification.json',
         )
-
-        sqs_handler = SqsHandler('us-west-2', 'godzilla')
-        created_objects = sqs_handler.get_created_objects()
-        created_objects = list(created_objects)
-        assert [] == created_objects
+        assert not list(sqs_handler.get_created_objects())

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,6 @@ tox_pip_extensions_ext_venv_update = true
 
 [testenv]
 deps = -rrequirements-dev.txt
-passenv = BOTO_CONFIG
 commands =
     flake8 .
     {envpython} --version


### PR DESCRIPTION
This will make the codebase compatible with the latest AWS technologies.
I removed `SqsQueueNotFoundException` because `boto3` will raise exceptions by itself when a queue does not exists.
I think this deserves a major version bump because of incompatibilities it may introduce with the previous status quo.
Also, solves #12.