### PR TITLE
catch error when tar.gz file is unreadable

### DIFF
--- a/amira/amira.py
+++ b/amira/amira.py
@@ -96,6 +96,10 @@ class AMIRA(object):
         )
         processed_input = self._data_processor.process_input(forensic_output)
 
+        if not processed_input:
+            logging.error('No input to process')
+            return
+
         try:
             self._data_processor.perform_analysis(processed_input, self._data_feeds)
         except Exception as exc:

--- a/amira/data_processor.py
+++ b/amira/data_processor.py
@@ -88,7 +88,13 @@ class OSXCollectorDataProcessor(DataProcessor):
         self._results = [FileMetaInfo('.tar.gz', ByteBuffer(tardata), 'application/gzip')]
         # create a file-like object based on the S3 object contents as string
         fileobj = ByteBuffer(tardata)
-        tar = tarfile.open(mode='r:gz', fileobj=fileobj)
+        tar = None
+        try:
+            tar = tarfile.open(mode='r:gz', fileobj=fileobj)
+        except tarfile.ReadError as ter:
+            logging.error('Failed to read the archive: {}'.format(ter))
+            return
+
         json_tarinfo = [t for t in tar if t.name.endswith('.json')]
 
         if len(json_tarinfo) != 1:

--- a/tests/amira_test.py
+++ b/tests/amira_test.py
@@ -65,6 +65,7 @@ class TestAmira(object):
 
         def mock_process_input(o, _):
             o._results = [FileMetaInfo('.tar.gz', ByteBuffer(b'1'), 'application/gzip')]
+            return MagicMock()
         mock_processor.process_input = types.MethodType(mock_process_input, mock_processor)
         mock_processor.perform_analysis = MagicMock()
         region_name, queue_name = 'us-west-2', 'etaoin-shrdlu'

--- a/tests/data_processor_test.py
+++ b/tests/data_processor_test.py
@@ -3,11 +3,13 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 
 import tarfile
+import logging
 
 import pytest
 from mock import ANY
 from mock import MagicMock
 from mock import patch
+from mock import call
 
 try:
     from cStringIO import StringIO as ByteBuffer
@@ -56,6 +58,13 @@ class TestOSXCollectorDataProcessor(object):
         output = processor.process_input(input_data)
         assert output.read() == b'{"a":2}\n'
         assert len(processor._results) == 1
+
+    def test_process_input_malformed_gz(self, tar_gz_mock):
+        logging.error = MagicMock()
+        processor = OSXCollectorDataProcessor()
+        tarfile.open.side_effect = tarfile.ReadError('mock.tar.gz is not a gz file')
+        processor.process_input(b'things')
+        logging.error.assert_has_calls([call(u'Failed to read the archive: mock.tar.gz is not a gz file')])
 
     def test_process_input_no_json(self, tar_gz_mock):
         processor = OSXCollectorDataProcessor()


### PR DESCRIPTION
This change fixes the below error, catches the exception in tarfile.open and logs the error:

` Traceback (most recent call last):
    tar = tarfile.open(mode="r:gz", fileobj=fileobj)
  File "/usr/lib/python3.7/tarfile.py", line 1591, in open
    return func(name, filemode, fileobj, **kwargs)
  File "/usr/lib/python3.7/tarfile.py", line 1649, in gzopen
    raise ReadError("not a gzip file")
tarfile.ReadError: not a gzip file 
`