### PR TITLE
set user to token

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -27,5 +27,5 @@ jobs:
     - name: Publish distribution package to PyPI
       uses: pypa/gh-action-pypi-publish@v1.2.2
       with:
-        user: yelplabs
+        user: __token__
         password: ${{ secrets.PYPI_TOKEN }}


### PR DESCRIPTION
As per https://pypi.org/help/#apitoken user needs to be set to __token__

```To use an API token:

Set your username to __token__
Set your password to the token value, including the pypi- prefix```